### PR TITLE
Add Downloaded with Pooled Requests

### DIFF
--- a/lib/web_stream/downloader.ex
+++ b/lib/web_stream/downloader.ex
@@ -1,0 +1,87 @@
+defmodule WebStream.Downloader do
+  alias WebStream.Request
+  alias WebStream.Downloader.Pool
+  alias WebStream.Downloader.PoolItem
+
+  use GenServer
+
+  defstruct downloading?: false,
+            pool: Pool.new,
+            max_concurrency: 10
+
+  def start_link do
+    HTTPoison.start
+    GenServer.start_link(__MODULE__, %__MODULE__{})
+  end
+
+  def fetch(pid, request) do
+    GenServer.cast(pid, {:fetch, request})
+  end
+
+  def downloaded(pid) do
+    GenServer.call(pid, :downloaded)
+  end
+
+  def handle_call(:downloaded, _from, state) do
+    {:reply, Pool.downloaded(state.pool), state}
+  end
+
+  def update_pool(pid, reference) do
+    GenServer.cast(pid, {:update_pool, reference}) 
+  end
+
+  def handle_cast({:fetch, request}, state) do
+    new_state = state
+      |> pool_request(request)
+      |> start_downloads
+      |> update_downloading_flag
+    {:noreply, new_state}
+  end
+
+  def handle_cast({:update_pool, reference}, state) do
+    new_state = state
+      |> pool_update(reference)
+      |> start_downloads
+      |> update_downloading_flag
+    {:noreply, new_state}
+  end
+
+  defp start_downloads(state) do
+    amount_to_download = state.max_concurrency - Pool.how_many?(state.pool, :downloading)
+    update_pool_download(state, amount_to_download)
+  end
+
+  defp update_pool_download(state, how_many) when how_many > 0 do
+    new_pool = state.pool
+      |> Pool.waiting
+      |> Enum.take(how_many)
+      |> Enum.map(fn { ref, item } ->
+           { ref,  item |> PoolItem.download(self(), &make_request/1) }
+         end)
+      |> Enum.into(state.pool)
+    %{ state | pool: new_pool }
+  end
+
+  defp update_pool_download(state, how_many) when how_many < 1 do
+    state
+  end
+
+  defp pool_update(state, reference) do
+    updated_item = state.pool
+      |> Pool.get(reference)
+      |> PoolItem.update
+    %{ state | pool: state.pool |> Pool.add( updated_item ) }
+  end
+
+  defp pool_request(state, request) do
+    %{ state | pool: state.pool |> Pool.add( PoolItem.new(request) ) }
+  end
+
+  defp update_downloading_flag(state) do
+    %{ state | downloading?: Pool.downloading?(state.pool) }
+  end
+
+  defp make_request(%Request{method: method, url: url, body: body, headers: headers, options: options}) do
+    HTTPoison.request(method, url, body, headers, options)
+  end
+end

--- a/lib/web_stream/downloader/pool.ex
+++ b/lib/web_stream/downloader/pool.ex
@@ -1,0 +1,54 @@
+defmodule WebStream.Downloader.Pool do
+  def new do
+    %{}
+  end
+
+  def downloaded(pool) do
+    pool |> filter_by_status(:finished)
+  end
+
+  def waiting(pool) do
+    pool |> filter_by_status(:waiting)
+  end
+
+  def references(pool) do
+    pool |> Dict.keys
+  end
+
+  def how_many?(pool, status) do
+    pool
+      |> Dict.values
+      |> Enum.filter(fn
+           %{ status: x } -> x == status 
+           _anything -> false
+         end)
+      |> Enum.count
+  end
+
+  def downloading?(pool) do
+    pool
+      |> Stream.map(fn {_,v} -> v end)
+      |> Enum.any?(fn
+           %{ status: :downloading } -> true
+           %{ status: :waiting } -> true
+           %{ status: _anything } -> false
+         end)
+  end
+
+  def add(pool, item) do
+    Dict.put(pool, item.reference, item)
+  end
+
+  def get(pool, ref) do
+    Dict.get(pool, ref)
+  end
+
+  defp filter_by_status(pool, status) do
+    pool
+      |> Stream.filter(fn
+           {_ref, %{ status: x } } -> x == status
+           _anything -> false
+         end)
+      |> Stream.into(new)
+  end
+end

--- a/lib/web_stream/downloader/pool_item.ex
+++ b/lib/web_stream/downloader/pool_item.ex
@@ -1,0 +1,27 @@
+defmodule WebStream.Downloader.PoolItem do
+  defstruct status: :waiting,
+            task: nil, 
+            response: nil,
+            request: nil,
+            reference: nil,
+            downloading?: false
+
+  def new(request) do
+    %__MODULE__{request: request, reference: make_ref()}
+  end
+
+  def download(item, server, fun) do
+    task = Task.async(fn ->
+      response = fun.(item.request)
+      # I don't like how this knows to ring back
+      WebStream.Downloader.update_pool(server, item.reference)
+      response
+    end)
+    %{ item | task: task, status: :downloading, downloading?: true }
+  end
+
+  def update(item) do
+    response = Task.await(item.task)
+    %{ item | response: response, status: :finished, downloading?: false }
+  end
+end

--- a/lib/web_stream/request.ex
+++ b/lib/web_stream/request.ex
@@ -1,0 +1,31 @@
+defmodule WebStream.Request do
+  defstruct method: nil, url: "", body: "", headers: [], options: []
+
+  def get(url, headers \\ [], options \\ []) do
+    %__MODULE__{method: :get, url: url, body: "", headers: headers, options: options}
+  end
+
+  def delete(url, headers \\ [], options \\ []) do
+    %__MODULE__{method: :delete, url: url, body: "", headers: headers, options: options}
+  end
+
+  def head(url, headers \\ [], options \\ []) do
+    %__MODULE__{method: :head, url: url, body: "", headers: headers, options: options}
+  end
+
+  def options(url, headers \\ [], options \\ []) do
+    %__MODULE__{method: :options, url: url, body: "", headers: headers, options: options}
+  end
+
+  def patch(url, body, headers \\ [], options \\ []) do
+    %__MODULE__{method: :patch, url: url, body: body, headers: headers, options: options}
+  end
+
+  def post(url, body, headers \\ [], options \\ []) do
+    %__MODULE__{method: :post, url: url, body: body, headers: headers, options: options}
+  end
+
+  def put(url, body, headers \\ [], options \\ []) do
+    %__MODULE__{method: :put, url: url, body: body, headers: headers, options: options}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,6 @@ defmodule WebStream.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    []
+    [{:httpoison, "~> 0.8.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,6 @@
+%{"certifi": {:hex, :certifi, "0.3.0"},
+  "hackney": {:hex, :hackney, "1.4.6"},
+  "httpoison": {:hex, :httpoison, "0.8.0"},
+  "idna": {:hex, :idna, "1.0.2"},
+  "mimerl": {:hex, :mimerl, "1.0.0"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}


### PR DESCRIPTION
This adds in the module `Webstream.Downloader` and provides
functionality to pool up a large number of downloaded requests
while limiting the number of concurrent requests being made.
